### PR TITLE
Add 4.1 Deprecated functions

### DIFF
--- a/vip-scanner/checks/DeprecatedFunctionsCheck.php
+++ b/vip-scanner/checks/DeprecatedFunctionsCheck.php
@@ -210,6 +210,11 @@ class DeprecatedFunctionsCheck extends CodeCheck {
 			'like_escape'               => '$wpdb->esc_like()',
 			'url_is_accessable_via_ssl' => '',
 			'get_all_category_ids'      => 'get_terms()',
+			// 4.1
+			'WP_Customize_Image_Control::prepare_control' => '',
+			'WP_Customize_Image_Control::add_tab' => '',
+			'WP_Customize_Image_Control::remove_tab' => '',
+			'WP_Customize_Image_Control::print_tab_image' => '',
 			/**
 			 * wp-admin
 			 */


### PR DESCRIPTION
Not gonna lie, not sure that format works for methods, but my main goal was to add something so the Travis CI tests run against the newer versions of the tests (5.4 instead of 5.3)
